### PR TITLE
Store payload as String for faster search/analyzing

### DIFF
--- a/composeApp/src/desktopMain/kotlin/com/alekso/dltstudio/MainViewModel.kt
+++ b/composeApp/src/desktopMain/kotlin/com/alekso/dltstudio/MainViewModel.kt
@@ -110,16 +110,14 @@ class MainViewModel(
                 yield()
                 val payload = dltMessage.payload
 
-                if (payload != null) {
-                    if ((_searchState.value.searchUseRegex && searchText.toRegex()
-                            .containsMatchIn(payload.asText()))
-                        || (payload.asText().contains(searchText))
-                    ) {
-                        searchResult.add(dltMessage)
-                        searchIndexes.add(i)
-                    }
-                    onProgressChanged(i.toFloat() / dltMessages.size)
+                if ((_searchState.value.searchUseRegex && searchText.toRegex()
+                        .containsMatchIn(payload))
+                    || (payload.contains(searchText))
+                ) {
+                    searchResult.add(dltMessage)
+                    searchIndexes.add(i)
                 }
+                onProgressChanged(i.toFloat() / dltMessages.size)
             }
             _searchState.value = _searchState.value.copy(
                 searchText = searchText,

--- a/composeApp/src/desktopMain/kotlin/com/alekso/dltstudio/logs/LazyScrollable.kt
+++ b/composeApp/src/desktopMain/kotlin/com/alekso/dltstudio/logs/LazyScrollable.kt
@@ -70,7 +70,7 @@ fun LazyScrollable(
                     val sSessionId: String = "${message.standardHeader.sessionId}"
                     val sApplicationId: String = "${message.extendedHeader?.applicationId}"
                     val sContextId: String = "${message.extendedHeader?.contextId}"
-                    val sContent: String = "${message.payload?.asText()}"
+                    val sContent: String = "${message.payload}"
                     val logTypeIndicator: LogTypeIndicator? =
                         LogTypeIndicator.fromMessageType(message.extendedHeader?.messageInfo?.messageTypeInfo)
 

--- a/composeApp/src/desktopMain/kotlin/com/alekso/dltstudio/logs/colorfilters/ColorFilter.kt
+++ b/composeApp/src/desktopMain/kotlin/com/alekso/dltstudio/logs/colorfilters/ColorFilter.kt
@@ -67,7 +67,7 @@ data class ColorFilter(
                 }
 
                 FilterParameter.Payload -> {
-                    checkTextCriteria(criteria, message.payload?.asText())
+                    checkTextCriteria(criteria, message.payload)
                 }
             }
         }

--- a/composeApp/src/desktopMain/kotlin/com/alekso/dltstudio/logs/infopanel/DLTDetailedLogInfoView.kt
+++ b/composeApp/src/desktopMain/kotlin/com/alekso/dltstudio/logs/infopanel/DLTDetailedLogInfoView.kt
@@ -8,11 +8,8 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.alekso.dltparser.dlt.ControlMessagePayload
 import com.alekso.dltparser.dlt.DLTMessage
 import com.alekso.dltparser.dlt.ExtendedHeader
-import com.alekso.dltparser.dlt.NonVerbosePayload
-import com.alekso.dltparser.dlt.VerbosePayload
 import com.alekso.dltparser.toBinary
 import com.alekso.dltparser.toHex
 
@@ -142,49 +139,12 @@ fun DLTDetailedInfoView(
 
                 }
 
+                Header(
+                    modifier = paddingModifier,
+                    text = "Payload:"
+                )
 
-                if (dltMessage.payload != null) {
-
-                    when (val payload = dltMessage.payload) {
-                        is VerbosePayload -> {
-                            Header(
-                                modifier = paddingModifier,
-                                text = "Verbose payload (${payload.arguments.size} arguments):"
-                            )
-
-                            payload.arguments.forEachIndexed { index, it ->
-                                TableRow(
-                                    0, "",
-                                    "#$index ${it.typeInfo.getTypeString()} ${it.payloadSize} bytes"
-                                )
-                                TableRow(0, "", it.getPayloadAsText())
-
-                            }
-                        }
-
-                        is NonVerbosePayload -> {
-                            Header(
-                                modifier = paddingModifier,
-                                text = "Non-Verbose payload:"
-                            )
-                            MonoText(
-                                modifier = paddingModifier,
-                                text = payload.asText()
-                            )
-                        }
-
-                        is ControlMessagePayload -> {
-                            Header(
-                                modifier = paddingModifier,
-                                text = "Control Message payload:"
-                            )
-                            MonoText(
-                                modifier = paddingModifier,
-                                text = payload.asText()
-                            )
-                        }
-                    }
-                }
+                TableRow(0, "", dltMessage.payload)
             }
         }
     }

--- a/composeApp/src/desktopMain/kotlin/com/alekso/dltstudio/logs/infopanel/DLTSimplifiedLogInfoView.kt
+++ b/composeApp/src/desktopMain/kotlin/com/alekso/dltstudio/logs/infopanel/DLTSimplifiedLogInfoView.kt
@@ -30,10 +30,7 @@ fun DLTSimplifiedInfoView(
                         "${dltMessage.extendedHeader?.applicationId} " +
                         "${dltMessage.extendedHeader?.contextId} "
                 TableRow(0, "", headerText)
-                if (dltMessage.payload != null) {
-                    val payloadText = dltMessage.payload!!.asText()
-                    TableRow(0, "", payloadText)
-                }
+                TableRow(0, "", dltMessage.payload)
             }
         }
     }

--- a/composeApp/src/desktopMain/kotlin/com/alekso/dltstudio/timeline/TimelineViewModel.kt
+++ b/composeApp/src/desktopMain/kotlin/com/alekso/dltstudio/timeline/TimelineViewModel.kt
@@ -19,6 +19,8 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.yield
 import java.io.File
 
+private const val PROGRESS_UPDATE_DEBOUNCE_MS = 30
+
 class TimelineViewModel(
     private val onProgressChanged: (Float) -> Unit
 ) {
@@ -159,6 +161,7 @@ class TimelineViewModel(
                     regexps.add(index, timelineFilter.extractPattern?.toRegex())
                 }
 
+                var prevTs  = System.currentTimeMillis()
                 dltMessages.forEachIndexed { index, message ->
                     yield()
                     // timeStamps
@@ -180,7 +183,11 @@ class TimelineViewModel(
                             )
                         }
                     }
-                    onProgressChanged(index.toFloat() / dltMessages.size)
+                    val nowTs = System.currentTimeMillis()
+                    if (nowTs - prevTs > PROGRESS_UPDATE_DEBOUNCE_MS) {
+                        prevTs = nowTs
+                        onProgressChanged(index.toFloat() / dltMessages.size)
+                    }
                 }
 
                 withContext(Dispatchers.Default) {

--- a/composeApp/src/desktopMain/kotlin/com/alekso/dltstudio/timeline/TimelineViewModel.kt
+++ b/composeApp/src/desktopMain/kotlin/com/alekso/dltstudio/timeline/TimelineViewModel.kt
@@ -2,7 +2,6 @@ package com.alekso.dltstudio.timeline
 
 import androidx.compose.runtime.mutableStateListOf
 import com.alekso.dltparser.dlt.DLTMessage
-import com.alekso.dltparser.dlt.VerbosePayload
 import com.alekso.dltstudio.logs.colorfilters.FilterCriteria
 import com.alekso.dltstudio.logs.colorfilters.FilterParameter
 import com.alekso.dltstudio.logs.colorfilters.TextCriteria
@@ -204,51 +203,16 @@ class TimelineViewModel(
         regex: Regex,
         entries: TimeLineEntries<*>
     ) {
-        if (message.payload !is VerbosePayload) return
         if (filter.extractPattern == null) return
 
         try {
             if (TimelineFilter.assessFilter(filter, message)) {
-                val payload = (message.payload as VerbosePayload).asText()
-                filter.diagramType.extractEntry(regex, payload, entries, message, filter)
+                filter.diagramType.extractEntry(regex, message.payload, entries, message, filter)
             }
         } catch (e: Exception) {
             // ignore
         }
     }
-
-
-//    private fun analyzeEntriesIndexOf(
-//        message: DLTMessage,
-//        appId: String? = null,
-//        contextId: String? = null,
-//        keyDelimiters: Pair<String, String>,
-//        valueDelimiters: Pair<String, String>,
-//        entries: TimelineEntriesHolder
-//    ) {
-//        if (message.payload !is VerbosePayload) return
-//        val payload = (message.payload as VerbosePayload).asText()
-//
-//        try {
-//            if (message.extendedHeader?.applicationId == appId && message.extendedHeader?.contextId == contextId) {
-//                val key: String? = payload.substring(
-//                    payload.indexOf(keyDelimiters.first) + keyDelimiters.first.length,
-//                    payload.indexOf(keyDelimiters.second)
-//                )
-//                val value: String? = payload.substring(
-//                    payload.indexOf(valueDelimiters.first) + valueDelimiters.first.length,
-//                    payload.indexOf(valueDelimiters.second)
-//                )
-//
-//                if (key != null && value != null) {
-//                    entries.addEntry(TimeLineSimpleEntry(message.timeStampNano, key, value))
-//                }
-//            }
-//        } catch (e: Exception) {
-//            // ignore
-//        }
-//    }
-
 
     fun onTimelineFilterUpdate(index: Int, filter: TimelineFilter) {
         if (index < 0 || index > timelineFilters.size) {

--- a/dltparser/src/commonMain/kotlin/com/alekso/dltparser/DLTParserV1.kt
+++ b/dltparser/src/commonMain/kotlin/com/alekso/dltparser/DLTParserV1.kt
@@ -51,9 +51,7 @@ class DLTParserV1: DLTParser {
 
                     try {
                         val dltMessage = parseDLTMessage(bytes, i, shouldLog)
-                        //if (dltMessage.extendedHeader?.applicationId == "PLAT" && dltMessage.extendedHeader?.contextId == "KVSS") {// applicationId=PLAT, contextId=KVSS
                         messages.add(dltMessage)
-                        //}
                         i += dltMessage.sizeBytes // skip read bytes
                     } catch (e: Exception) {
                         i++ // move counter to the next byte
@@ -163,7 +161,7 @@ class DLTParserV1: DLTParser {
             println("")
         }
 
-        return DLTMessage(timeStampNano, ecuId, standardHeader, extendedHeader, payload, i - offset)
+        return DLTMessage(timeStampNano, ecuId, standardHeader, extendedHeader, payload?.asText() ?: "", i - offset)
     }
 
     private fun parseStandardHeader(shouldLog: Boolean, bytes: ByteArray, i: Int): StandardHeader {

--- a/dltparser/src/commonMain/kotlin/com/alekso/dltparser/dlt/DLTMessage.kt
+++ b/dltparser/src/commonMain/kotlin/com/alekso/dltparser/dlt/DLTMessage.kt
@@ -13,7 +13,7 @@ data class DLTMessage(
     val ecuId: String,
     val standardHeader: StandardHeader,
     val extendedHeader: ExtendedHeader?,
-    val payload: Payload?,
+    val payload: String,
     // meta info
     val sizeBytes: Int,
 ) {

--- a/dltparser/src/commonMain/kotlin/com/alekso/dltparser/dlt/SampleData.kt
+++ b/dltparser/src/commonMain/kotlin/com/alekso/dltparser/dlt/SampleData.kt
@@ -40,7 +40,7 @@ object SampleData {
                             ), 12, 10, "TEST MESSAGE".toByteArray()
                         )
                     )
-                ),
+                ).asText(),
                 122
             )
             list.add(dltMessage)


### PR DESCRIPTION
Logs searching and timeline analyzing happen more often than file parsing. In this case it makes sense to store payload as text - this slows down initial file parsing but on another hand drastically improves working with parsed  messages.
Theoretically, memory consumption will be lower with string payload representation.

1GB DLT file test (7.156.519 messages)
|  | Parsing | Searching | Analyzing | Total time |
| - | - | - | - | - |
| Raw payload | 5s | 71s | 28s | 104s |
| String payload | 43s | 19s | 24s | 86s |
| Raw payload + progress update frequency limit | 4s | 68s | 19s | 91s |
| String payload + progress update frequency limit | 34s | 17s | 17s | 68s |


