### PR TITLE
Use user's home directory to store app preferences

### DIFF
--- a/composeApp/src/desktopMain/kotlin/com/alekso/dltstudio/preferences/Preferences.kt
+++ b/composeApp/src/desktopMain/kotlin/com/alekso/dltstudio/preferences/Preferences.kt
@@ -33,7 +33,7 @@ object Preferences {
 
         if (platform.startsWith("Mac OS")) {
             val path =
-                "${System.getProperty("user.home")}/Library/Preferences/$PREFERENCES_FILES_NAME"
+                "${System.getProperty("user.home")}/$PREFERENCES_FILES_NAME"
             println("Preferences path $path")
             File(path)
         } else { // todo: Linux/Win implementation


### PR DESCRIPTION
It seems that `~/Library/Preferences` is not available for all users.