### PR TITLE
Stable message key

### DIFF
--- a/composeApp/src/desktopMain/kotlin/com/alekso/dltstudio/logs/LazyScrollable.kt
+++ b/composeApp/src/desktopMain/kotlin/com/alekso/dltstudio/logs/LazyScrollable.kt
@@ -69,7 +69,7 @@ fun LazyScrollable(
                 }
                 itemsIndexed(
                     items = logMessages,
-                    key = { _, log -> log.getKey() },
+                    key = { _, log -> log.key },
                     contentType = { _, _ -> LogMessage::class }) { i, logMessage ->
 
                     val dltMessage = logMessage.dltMessage

--- a/composeApp/src/desktopMain/kotlin/com/alekso/dltstudio/logs/LogsListPanel.kt
+++ b/composeApp/src/desktopMain/kotlin/com/alekso/dltstudio/logs/LogsListPanel.kt
@@ -51,7 +51,9 @@ fun LogsListPanel(
 @Composable
 fun PreviewLogsListPanel() {
     val list = SnapshotStateList<LogMessage>()
-    list.addAll(SampleData.getSampleDltMessages(20).map { LogMessage(it, true, "Test comment") })
+    list.addAll(
+        SampleData.getSampleDltMessages(20)
+            .map { LogMessage(dltMessage = it, marked = true, comment = "Test comment") })
 
     LogsListPanel(
         modifier = Modifier.fillMaxSize(),

--- a/composeApp/src/desktopMain/kotlin/com/alekso/dltstudio/model/LogMessage.kt
+++ b/composeApp/src/desktopMain/kotlin/com/alekso/dltstudio/model/LogMessage.kt
@@ -5,6 +5,7 @@ import com.alekso.dltstudio.logs.LogTypeIndicator
 
 data class LogMessage(
     val dltMessage: DLTMessage,
+    val key: String = "${counter++}",
     val marked: Boolean = false,
     val comment: String? = null,
 ) {
@@ -17,8 +18,7 @@ data class LogMessage(
                 dltMessage.payload
     }
 
-    /**
-     * Unique key for log message
-     */
-    fun getKey(): String = "${dltMessage.timeStampNano}:${dltMessage.standardHeader.messageCounter}"
+    companion object {
+        var counter = 0
+    }
 }

--- a/composeApp/src/desktopMain/kotlin/com/alekso/dltstudio/model/LogMessage.kt
+++ b/composeApp/src/desktopMain/kotlin/com/alekso/dltstudio/model/LogMessage.kt
@@ -2,10 +2,11 @@ package com.alekso.dltstudio.model
 
 import com.alekso.dltparser.dlt.DLTMessage
 import com.alekso.dltstudio.logs.LogTypeIndicator
+import java.util.concurrent.atomic.AtomicInteger
 
 data class LogMessage(
     val dltMessage: DLTMessage,
-    val key: String = "${counter++}",
+    val key: String = "${counter.getAndIncrement()}",
     val marked: Boolean = false,
     val comment: String? = null,
 ) {
@@ -19,6 +20,7 @@ data class LogMessage(
     }
 
     companion object {
-        var counter = 0
+        @Volatile
+        var counter = AtomicInteger(0)
     }
 }


### PR DESCRIPTION
It turned out that timeStampNano and messageCounter are not unique, some DLT files contain identical values for these fields.
Solution would be to Initialize every log with unique key.