### PR TITLE
PoC: Try to fix order by ECU time then message count if timeStampUs order is broken

### DIFF
--- a/desktop-app/src/desktopMain/kotlin/com/alekso/dltstudio/MainViewModel.kt
+++ b/desktop-app/src/desktopMain/kotlin/com/alekso/dltstudio/MainViewModel.kt
@@ -186,7 +186,8 @@ class MainViewModel(
                 dltParser.read(
                     dltFiles,
                     settingsLogs.value.backendType,
-                    DependencyManager.onProgressUpdate
+                    DependencyManager.onProgressUpdate,
+                    true,
                 ).map { LogMessage(it) })
         }
     }

--- a/desktop-app/src/desktopMain/kotlin/com/alekso/dltstudio/logs/LazyScrollable.kt
+++ b/desktop-app/src/desktopMain/kotlin/com/alekso/dltstudio/logs/LazyScrollable.kt
@@ -116,16 +116,15 @@ fun LazyScrollable(
                         colorFilters.firstOrNull { filter -> filter.assess(dltMessage) }?.cellStyle
 
                     val index: Int = if (indexes != null) indexes[i] else i
-                    val sTime: String =
-                        LocalFormatter.current.formatDateTime(dltMessage.timeStampUs)
-                    val sTimeOffset: String =
-                        if (dltMessage.standardHeader.timeStamp != null) "%.4f".format(dltMessage.standardHeader.timeStamp!!.toLong() / 10000f) else "-"
+                    val sTime = LocalFormatter.current.formatDateTime(dltMessage.timeStampUs)
+                    val timeStamp = dltMessage.standardHeader.timeStamp
+                    val sTimeOffset = if (timeStamp != null) timeStamp.toString() else "-"
                     val sEcuId = "${dltMessage.standardHeader.ecuId}"
                     val sSessionId = "${dltMessage.standardHeader.sessionId}"
                     val sMessageCounterId = "${dltMessage.standardHeader.messageCounter}"
                     val sApplicationId = "${dltMessage.extendedHeader?.applicationId}"
                     val sContextId = "${dltMessage.extendedHeader?.contextId}"
-                    val sContent: String = dltMessage.payloadText()
+                    val sContent = dltMessage.payloadText()
                     val logTypeIndicator: LogTypeIndicator? =
                         LogTypeIndicator.fromMessageType(dltMessage.extendedHeader?.messageInfo?.messageTypeInfo)
 

--- a/dlt-parser/src/commonMain/kotlin/com/alekso/dltparser/DLTParser.kt
+++ b/dlt-parser/src/commonMain/kotlin/com/alekso/dltparser/DLTParser.kt
@@ -26,6 +26,7 @@ interface DLTParser {
         files: List<File>,
         payloadStorageType: PayloadStorageType,
         progressCallback: (Float) -> Unit,
+        fixOrdering: Boolean = false,
     ): List<DLTMessage>
 
 }


### PR DESCRIPTION
Sometimes timeStampUs order is wrong and it's visible by ECU time.
Solution: Sort messages by ECU time and message counter, then group them by ECU. In the end, build up the final list by taking top elements depending on timeStampUs.
NB: So far this is a brute force algorithm and is not efficient.