### PR TITLE
Don't crash on wrong regex

### DIFF
--- a/model-contract/src/commonMain/kotlin/com/alekso/dltstudio/model/contract/filtering/TextCriteria.kt
+++ b/model-contract/src/commonMain/kotlin/com/alekso/dltstudio/model/contract/filtering/TextCriteria.kt
@@ -11,6 +11,10 @@ fun checkTextCriteria(criteria: FilterCriteria, message: String?): Boolean {
     return when (criteria.textCriteria) {
         TextCriteria.PlainText -> message?.contains(criteria.value) ?: false
         TextCriteria.LowerCase -> message?.lowercase()?.contains(criteria.value) ?: false
-        TextCriteria.Regex -> message?.contains(criteria.value.toRegex()) ?: false
+        TextCriteria.Regex -> try {
+            message?.contains(Regex(criteria.value))
+        } catch (e: Exception) {
+            false
+        } ?: false
     }
 }


### PR DESCRIPTION
Fixed crash when using errors in regex, like forgotten ")"