### PR TITLE
Update messages on Main dispatcher to prevent IOOBE

### DIFF
--- a/desktop-app/src/desktopMain/kotlin/com/alekso/dltstudio/MainViewModel.kt
+++ b/desktop-app/src/desktopMain/kotlin/com/alekso/dltstudio/MainViewModel.kt
@@ -441,8 +441,8 @@ class MainViewModel(
             pluginManager.notifyLogsChanged()
         }
         parseJob?.cancel()
-        clearMessages()
         parseJob = viewModelScope.launch(IO) {
+            clearMessages()
             LogMessage.resetCounter()
             messagesRepository.storeMessages(
                 dltParser.read(
@@ -474,8 +474,10 @@ class MainViewModel(
         settingsDialogState = false
     }
 
-    private fun clearMessages() {
-        messagesRepository.clearMessages()
+    private suspend fun clearMessages() {
+        withContext(Main) {
+            messagesRepository.clearMessages()
+        }
     }
 
 

--- a/desktop-app/src/desktopMain/kotlin/com/alekso/dltstudio/logs/MessagesRepositoryImpl.kt
+++ b/desktop-app/src/desktopMain/kotlin/com/alekso/dltstudio/logs/MessagesRepositoryImpl.kt
@@ -18,22 +18,30 @@ class MessagesRepositoryImpl : MessagesRepository {
     private var searchResults = mutableStateListOf<LogMessage>()
     private val selectedMessage = mutableStateOf<LogMessage?>(null)
 
-    override fun clearMessages() {
-        logMessages.clear()
-        clearSearchResults()
+    override suspend fun clearMessages() {
+        withContext(Main) {
+            logMessages.clear()
+            clearSearchResults()
+        }
     }
 
-    private fun clearSearchResults() {
-        searchResults.clear()
+    private suspend fun clearSearchResults() {
+        withContext(Main) {
+            searchResults.clear()
+        }
     }
 
-    override fun storeMessages(logMessages: List<LogMessage>) {
-        this.logMessages.clear()
-        this.logMessages.addAll(logMessages)
+    override suspend fun storeMessages(messages: List<LogMessage>) {
+        withContext(Main) {
+            logMessages.clear()
+            logMessages.addAll(messages)
+        }
     }
 
-    private fun addSearchResult(logMessages: LogMessage, index: Int) {
-        searchResults.add(logMessages)
+    private suspend fun addSearchResult(logMessages: LogMessage, index: Int) {
+        withContext(Main) {
+            searchResults.add(logMessages)
+        }
     }
 
     override fun getMessages(): SnapshotStateList<LogMessage> {

--- a/plugins/contract/src/commonMain/kotlin/com/alekso/dltstudio/plugins/contract/MessagesRepository.kt
+++ b/plugins/contract/src/commonMain/kotlin/com/alekso/dltstudio/plugins/contract/MessagesRepository.kt
@@ -5,8 +5,8 @@ import androidx.compose.runtime.snapshots.SnapshotStateList
 import com.alekso.dltstudio.model.contract.LogMessage
 
 interface MessagesRepository {
-    fun clearMessages()
-    fun storeMessages(logMessages: List<LogMessage>)
+    suspend fun clearMessages()
+    suspend fun storeMessages(messages: List<LogMessage>)
     fun getMessages(): SnapshotStateList<LogMessage>
     fun getSearchResults(): SnapshotStateList<LogMessage>
     fun getSelectedMessage(): State<LogMessage?>

--- a/plugins/manager/src/commonTest/kotlin/com/alekso/dltstudio/plugins/LoadingPluginTest.kt
+++ b/plugins/manager/src/commonTest/kotlin/com/alekso/dltstudio/plugins/LoadingPluginTest.kt
@@ -17,8 +17,8 @@ class PluginTest {
     fun `Test Loading Jar test plugin`() {
         val messagesProvider = object : MessagesRepository {
             private val messages = mutableStateListOf<LogMessage>()
-            override fun clearMessages() = Unit
-            override fun storeMessages(logMessages: List<LogMessage>) = Unit
+            override suspend fun clearMessages() = Unit
+            override suspend fun storeMessages(messages: List<LogMessage>) = Unit
             override fun getMessages(): SnapshotStateList<LogMessage> = messages
             override fun getSearchResults(): SnapshotStateList<LogMessage> = mutableStateListOf()
             override fun getSelectedMessage(): State<LogMessage?> = mutableStateOf(null)


### PR DESCRIPTION
Updating SnapshotStateList on different dispatchers leads to IndexOutOfBoundException. This led to sporadic app crashes during logs search/removal. 
To prevent such issues messages now are updated only from the Main dispatcher.